### PR TITLE
Making type part of composed sort key

### DIFF
--- a/src/statikk/engine.py
+++ b/src/statikk/engine.py
@@ -170,6 +170,8 @@ class SingleTableApplication:
             if set(field_info.annotation.__bases__).intersection({IndexSecondaryKeyField})
             and idx.name in getattr(model, field_name).index_names
         ]
+        if "type" not in sort_key_fields:
+            sort_key_fields.insert(0, "type")
 
         def _get_sort_key_value():
             if len(sort_key_fields) == 0:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -130,7 +130,7 @@ def test_multi_index_table():
         "gsi_pk": "123",
         "gsi_sk": "DoubleIndexModel|LEGENDARY",
         "gsi_pk_2": "abc",
-        "gsi_sk_2": "2023-09-10 12:00:00",
+        "gsi_sk_2": "DoubleIndexModel|2023-09-10 12:00:00",
     }
     mock_dynamodb().stop()
 


### PR DESCRIPTION
Type is basically a safety valve for queries - it makes sure that the model we query returns values unique to the model and avoids cases where hierarchical queries can return unexpected items.

For example, if we have:

```
class A(DatabaseModel):
    player_id: IndexPrimaryKeyField[str]
    tier: IndexSecondaryKeyField[str]

class B(DatabaseModel):
    player_id: IndexPrimaryKeyField[str]
    name: IndexSecondaryKeyField[str]

a = A(player_id='123', tier='legendary')
b = B(player_id='123', name='legendary biscuit')

then the following query would return both items and fail:

models = app.query_index(hash_key=Equals('123'), range_key=BeginsWith('legendary'))

```