### PR TITLE
Adding 'type' as field to all models

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -63,6 +63,12 @@ Model definition
         # models that share the same primary key. Here however, we want the type to be the primary key only.
         return False
 
+    @classmethod
+    def model_type(cls):
+      # The default return value for this method is the name of the class, but feel free to override it here to whatever
+      # you'd like present in the sort key.
+      return "Player"
+
 
   class Card(DatabaseModel):
     id: str

--- a/src/statikk/conditions.py
+++ b/src/statikk/conditions.py
@@ -37,8 +37,8 @@ class BeginsWith(Condition):
         return Key(key).begins_with(self.value)
 
     def enrich(self, model_class, **kwargs):
-        if not self.value.startswith(model_class.type()) and model_class.include_type_in_sort_key():
-            self.value = f"{model_class.type()}|{self.value}"
+        if not self.value.startswith(model_class.model_type()) and model_class.include_type_in_sort_key():
+            self.value = f"{model_class.model_type()}|{self.value}"
 
 
 class LessThan(Condition):

--- a/src/statikk/models.py
+++ b/src/statikk/models.py
@@ -54,7 +54,7 @@ class DatabaseModel(BaseModel):
     id: str
 
     @classmethod
-    def type(cls):
+    def model_type(cls):
         return cls.__name__
 
     @classmethod

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -88,6 +88,7 @@ def test_create_my_awesome_model():
         "name": "Foo",
         "values": {1, 2, 3, 4},
         "cost": 4,
+        "type": "MyAwesomeModel",
     }
     model_2 = MyAwesomeModel(id="foo-2", player_id="123", tier="EPIC", name="FooFoo")
     table.put_item(model_2)
@@ -100,6 +101,7 @@ def test_create_my_awesome_model():
         "name": "FooFoo",
         "values": {1, 2, 3, 4},
         "cost": 4,
+        "type": "MyAwesomeModel",
     }
     mock_dynamodb().stop()
 
@@ -142,6 +144,7 @@ def test_multi_index_table():
         "gsi_sk": "DoubleIndexModel|LEGENDARY",
         "gsi_pk_2": "abc",
         "gsi_sk_2": datetime(2023, 9, 10, 10, 0, tzinfo=timezone.utc),
+        "type": "DoubleIndexModel",
     }
     mock_dynamodb().stop()
 
@@ -214,6 +217,7 @@ def test_multi_field_index():
         "player_id": "123",
         "tier": "LEGENDARY",
         "values": [1, 2, 3, 4],
+        "type": "MultiIndexModel",
     }
     mock_dynamodb().stop()
 
@@ -281,7 +285,7 @@ def test_query_model_index():
     )
     assert len(models) == 1
     assert models[0].id == model.id
-    assert models[0].type == model.type
+    assert models[0].model_type == model.model_type
     assert models[0].tier == model.tier
     mock_dynamodb().stop()
 
@@ -316,7 +320,7 @@ def test_query_index_name_is_provided():
     )
     assert len(models) == 1
     assert models[0].id == model.id
-    assert models[0].type == model.type
+    assert models[0].model_type == model.model_type
     assert models[0].tier == model.tier
     mock_dynamodb().stop()
 
@@ -343,10 +347,10 @@ def test_batch_get_items():
     models = table.batch_get_items(["foo", "foo-2"], MyAwesomeModel, batch_size=1)
     assert len(models) == 2
     assert models[0].id == model.id
-    assert models[0].type == model.type
+    assert models[0].model_type == model.model_type
     assert models[0].tier == model.tier
     assert models[1].id == model_2.id
-    assert models[1].type == model_2.type
+    assert models[1].model_type == model_2.model_type
     assert models[1].tier == model_2.tier
     mock_dynamodb().stop()
 
@@ -508,7 +512,7 @@ def test_type_is_primary_key():
             return False
 
         @classmethod
-        def type(cls):
+        def model_type(cls):
             return "my-type"
 
     mock_dynamodb().start()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,7 +17,7 @@ def test_index_shorthand():
 
     with patch("statikk.models.uuid.uuid4", return_value="123"):
         foo = Foo(player_id="abc")
-        assert foo.type() == "Foo"
+        assert foo.model_type() == "Foo"
         assert foo.id == "123"
         assert foo.player_id.value == "abc"
         assert foo.player_id.index_names == ["main-index"]


### PR DESCRIPTION
This will allow filtering on the type field for indexes where type is not part of the sort key (most typically where sort key is not of type str)