### PR TITLE
Fixing datetime serialization and removing some unnecessary code

### DIFF
--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -143,7 +143,7 @@ def test_multi_index_table():
         "gsi_pk": "123",
         "gsi_sk": "DoubleIndexModel|LEGENDARY",
         "gsi_pk_2": "abc",
-        "gsi_sk_2": datetime(2023, 9, 10, 10, 0, tzinfo=timezone.utc),
+        "gsi_sk_2": datetime(2023, 9, 10, 12, 0),
         "type": "DoubleIndexModel",
     }
     mock_dynamodb().stop()


### PR DESCRIPTION
datetime serialization was still a little problematic when unit tests were using freezegun to mock the datetime libray, because checking the field's annotation was not working correctly anmore.

Since the models are usually defined outside the scope of the unit test, they had the correct `datetime` annotation as one would expect.

At runtime, once the datetime module gets monkey patched by freezegun, the module itself becomes a different type `<class FakeDateTime>`.

The code was relying on checking if the annotation of the field was that of `datetime`, but in scenarios such as this, it was failing.

For now this solution should suffice, though it is quite janky.