### PR TITLE
Adding support for index field ordering

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -159,7 +159,7 @@ More advanced queries
 ====================
 
 Most times, Single Table Applications rely on their index fields to be constructed of multiple different values. Statikk does this for you
-based on all the IndexSecondaryKeyField fields you define on your models. If you have more than 1 IndexSecondaryKeyField, Statikk will produce
+based on all the IndexSecondaryKeyField fields you define on your models. If you have more than 1 IndexSecondaryKeyField, by default Statikk will produce
 the constructed index value based on the **order of the fields** you define. This is very useful, if you want to set up hierarchical queries on your data.
 
 Let's take a look at an example:
@@ -178,9 +178,17 @@ This setup allows you to search using the following patterns:
  - Get all cards belonging to a player by their origin and tier
 
 Note that the order is **REALLY** important here. Swapping up the order in on your production data will cause absolute havoc on your queries
-and will taint your data. So be careful! Statikk will not prevent you from doing this, because it's not possible to do so.
+and will taint your data.
 
-There is some work planned to make this a bit more robust, but for now, you'll have to pay attention.
+It is **HIGHLY RECOMMENDED** to manually define the order property on your secondary index fields.
+
+.. code-block:: python
+
+    class MultiKeyCard(DatabaseModel):
+      id: str
+      player_id: IndexPrimaryKeyField
+      origin: IndexSecondaryKeyField(order=1)
+      tier: IndexSecondaryKeyField(order=2)
 
 ====================
 Multiple indexes

--- a/src/statikk/engine.py
+++ b/src/statikk/engine.py
@@ -395,12 +395,17 @@ class Table:
         if len(hash_key_field) == 0 and model.type_is_primary_key():
             hash_key_field.append(model.model_type())
         hash_key_field = hash_key_field[0]
-        sort_key_fields = [
-            field_name
+        sort_key_fields_unordered = [
+            (field_name, getattr(model, field_name).order)
             for field_name, field_info in model_fields.items()
             if field_info.annotation is not None
             if field_info.annotation is IndexSecondaryKeyField and idx.name in getattr(model, field_name).index_names
         ]
+
+        if sort_key_fields_unordered[0][1] is not None:
+            sort_key_fields_unordered.sort(key=lambda x: x[1])
+
+        sort_key_fields = [field[0] for field in sort_key_fields_unordered]
 
         def _get_sort_key_value():
             if len(sort_key_fields) == 0 and model.include_type_in_sort_key():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,8 @@
 from unittest.mock import patch
 
+import pytest
+from pydantic_core._pydantic_core import ValidationError
+
 from statikk.models import (
     DatabaseModel,
     IndexPrimaryKeyField,
@@ -30,3 +33,34 @@ def test_index_configuration():
     foo = FooNotMainIndex(type="FooNotMainIndex")
     assert foo.type.value == "FooNotMainIndex"
     assert foo.type.index_names == ["not-main-index"]
+
+
+def test_invalid_order_config_on_indexes():
+    class InvalidOrderingModel(DatabaseModel):
+        player_id: IndexPrimaryKeyField
+        tier: IndexSecondaryKeyField = IndexSecondaryKeyField(order=1)
+        unit_class: IndexSecondaryKeyField
+
+    with pytest.raises(ValidationError):
+        InvalidOrderingModel(player_id="abc", unit_class="foo")
+
+
+def test_all_orders_are_configued_on_indexes():
+    class AllOrdersConfiguredModel(DatabaseModel):
+        player_id: IndexPrimaryKeyField
+        tier: IndexSecondaryKeyField = IndexSecondaryKeyField(order=1)
+        unit_class: IndexSecondaryKeyField = IndexSecondaryKeyField(order=2)
+
+    model = AllOrdersConfiguredModel(player_id="abc", unit_class="foo", tier="bar")
+    assert model.tier.order == 1
+    assert model.unit_class.order == 2
+
+
+def test_same_order_defined_on_fields():
+    class SameOrderDefinedOnFields(DatabaseModel):
+        player_id: IndexPrimaryKeyField
+        tier: IndexSecondaryKeyField = IndexSecondaryKeyField(order=1)
+        unit_class: IndexSecondaryKeyField = IndexSecondaryKeyField(order=1)
+
+    with pytest.raises(ValidationError):
+        SameOrderDefinedOnFields(player_id="abc", unit_class="foo", tier="bar")


### PR DESCRIPTION
Relying on the order in which these properties are defined on a model is fairly error-prone and requires deep knowledge of this library.

Exposing a specific order field for index fields makes it much clearer how the sort key value is going to be constructed and makes the usage of this library safer.